### PR TITLE
Don't minify if response is instance of StreamedResponse

### DIFF
--- a/src/HtmlMinifyMiddleware.php
+++ b/src/HtmlMinifyMiddleware.php
@@ -18,7 +18,7 @@ class HtmlMinifyMiddleware
     public function handle(Request $request, \Closure $next)
     {
         $response = $next($request);
-        
+
         if ($response instanceof StreamedResponse) {
             return $next($request);
         }

--- a/src/HtmlMinifyMiddleware.php
+++ b/src/HtmlMinifyMiddleware.php
@@ -18,6 +18,10 @@ class HtmlMinifyMiddleware
     public function handle(Request $request, \Closure $next)
     {
         $response = $next($request);
+        
+        if ($response instanceof StreamedResponse) {
+            return $next($request);
+        }
 
         $config_prefix = 'html-minify';
 


### PR DESCRIPTION
This pull request fixes #5, where when using Glide to generate images, it would return a `StreamedResponse` instance which would end up [throwing an exception](http://flareapp.io/share/Bm01zDeP).