### PR TITLE
Don't minify a JSON response

### DIFF
--- a/src/HtmlMinifyMiddleware.php
+++ b/src/HtmlMinifyMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Octoper\HtmlMinify;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -19,7 +20,7 @@ class HtmlMinifyMiddleware
     {
         $response = $next($request);
 
-        if ($response instanceof StreamedResponse) {
+        if ($response instanceof StreamedResponse || $response instanceof JsonResponse) {
             return $next($request);
         }
 


### PR DESCRIPTION
Hey again!

Just ran into another issue with `statamic-html-minify` where it was attempting to minify JSON responses. 

This caused Livewire to return an invalid response (due to syntax issues). I imagine this would also cause issues if someone installed Statamic & this addon onto a project with an API, the same sort of problem would occur.

I've added `$response instanceof JsonResponse` to the conditional of ignored responses. I wonder if this should maybe be the opposite? So it only runs if the response is an instance of an HtmlResponse (not sure if that actually exists)?