### PR TITLE
Remove duplicate response calls

### DIFF
--- a/src/HtmlMinifyMiddleware.php
+++ b/src/HtmlMinifyMiddleware.php
@@ -22,7 +22,7 @@ class HtmlMinifyMiddleware
         $response = $next($request);
 
         if ($response instanceof StreamedResponse || $response instanceof JsonResponse) {
-            return $next($request);
+            return $response;
         }
 
         if ($response instanceof Response && $this->isValidHTMLResponse($response)) {
@@ -31,7 +31,7 @@ class HtmlMinifyMiddleware
             return $response->setContent($html);
         }
 
-        return $next($request);
+        return $response;
     }
 
     protected function isValidHTMLResponse($response)


### PR DESCRIPTION
This PR removes the duplicated `$next($request)` calls, which resulted in duplicate requests. For instance, 2 ajax requests would be processed for the same call.